### PR TITLE
ci: set dependabot pull request limit to 30

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
+    open-pull-requests-limit: 30
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"


### PR DESCRIPTION
## Description

This pull request raises the Dependabot `open-pull-requests-limit` to 30 for every package ecosystem in `.github/dependabot.yml`.

## Related Issue(s)

Refs FlowFuse/engineering#93

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label
